### PR TITLE
关于在线更新的几处改动

### DIFF
--- a/main.js
+++ b/main.js
@@ -257,7 +257,7 @@ ui.start.click(() => {
 //版本获取
 http.__okhttp__.setTimeout(5000);
 try {
-    let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle/project.json");
+    let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest/project.json");
     if (res.statusCode != 200) {
         log("请求失败: " + res.statusCode + " " + res.statusMessage);
         ui.run(function () {
@@ -288,7 +288,7 @@ try {
 //版本更新
 function toUpdate() {
     try {
-        let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle/project.json");
+        let res = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@latest/project.json");
         if (res.statusCode != 200) {
             toastLog("请求超时")
         } else {
@@ -296,21 +296,19 @@ function toUpdate() {
             if (parseInt(resJson.versionName.split(".").join("")) <= parseInt(version.split(".").join(""))) {
                 toastLog("无需更新")
             } else {
-                let main_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle/main.js");
-                let float_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle/floatUI.js");
+                let main_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@"+resJson.versionName+"/main.js");
+                let float_script = http.get("https://cdn.jsdelivr.net/gh/icegreentee/magireco_autoBattle@"+resJson.versionName+"/floatUI.js");
                 if (main_script.statusCode == 200 && float_script.statusCode == 200) {
                     toastLog("更新加载中");
                     let mainjs = main_script.body.string();
                     let floatjs = float_script.body.string();
-                    let prjjson = res.body.string();
                     files.write(engines.myEngine().cwd() + "/main.js", mainjs)
                     files.write(engines.myEngine().cwd() + "/floatUI.js", floatjs)
-                    files.write(engines.myEngine().cwd() + "/project.json", prjjson)
-                    engines.stopAll()
                     events.on("exit", function () {
                         engines.execScriptFile(engines.myEngine().cwd() + "/main.js")
                         toast("更新完毕")
                     })
+                    engines.stopAll()
                 } else {
                     toast("脚本获取失败！这可能是您的网络原因造成的，建议您检查网络后再重新运行软件吧\nHTTP状态码:" + main_script.statusMessage, "," + float_script.statusMessag);
                 }


### PR DESCRIPTION
1.在更新URL中指定版本号，防止下载到不一致的文件。

其实每次刷新JSDelivr时，都要把每一个文件都刷新一次。之前我还不知道这个，只刷新了项目根目录，然后下面的文件有些更新了，有些没更新。

这个问题是怎么发现的呢？我做了更新文件hash值检查机制，然后我发现，有的时候执行在线更新后，就总是处于hash值校验不通过的状态。（而且我还让脚本在hash值检查不通过时拒绝开始运行，于是就不能忽略这个问题继续运行）

*“更新文件hash值检查机制”其实不止检查hash值，还有一大功能：更新时按照文件列表进行下载和覆盖更新，而不是现在这样写死只有floatUI.js和main.js这样。为了识图，我在脚本里打包了很多参考图片，而且还有scrcap2bmp这个原生程序用来转换截图格式，文件数量比较多，而且未来可能还会增补，所以才需要这个功能*

后来知道了原因，下载文件时，在URL里指定了确定的版本号，这个问题就解决了。

另外我记得前几天有一次刷新JSDelivr，好像不加@ latest的URL还刷不动，后来过了大概一天又好了。

------

2.不更新project.json，避免触发回滚

貌似autojs会检测`project.json`的内容，在强行停止app运行后再启动时，如果发现不一致，脚本文件就会被回滚到打包apk时的版本。

------

3.调换注册exit事件回调和停止脚本引擎的顺序

这个我懒得再去实验了。我记得就现在这个不调换好像也可以正常更新完成后重启；但是出于强迫症，我还是想调换过来（按理说先停止脚本引擎的话，应该直接就退出不会重启才对？）。我魔改的版本一直就是这样，先注册exit事件回调，然后再停止脚本引擎。